### PR TITLE
Use Ubuntu 20.04 for Python 3 as default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: minimal
 
-dist: bionic
+dist: focal
 
 env:
   - DOCKER_COMPOSE_VERSION=1.25.5

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='django_informixdb_vault',
-    version='0.2.0',
+    version='0.2.1',
     description='A database driver for Django to connect to an Informix db via ODBC, obtaining the credentials from Hashicorp Vault',
     long_description=long_description,
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
This should help our Python 2.7 - therefore failing to publish to PyPi issue - see #8 

Couldn't be tested on a branch due to it being a branch:
```
Skipping a deployment with the pypi provider because this branch is not permitted: fix-travis-publish
```

But at least we can see the rest of the build was successful on Ubuntu 20.04 / focal