### PR TITLE
Drop Django 2 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     ],
     keywords='django informix vault',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
-    install_requires=['django>=2.2.0,<4', 'pyodbc~=4.0.21', 'django_informixdb~=1.10.0', 'hvac~=0.10.4'],
+    install_requires=['django>=3.2.0,<4', 'pyodbc~=4.0.21', 'django_informixdb~=1.10.0', 'hvac~=0.10.4'],
     extras_require={
         'dev': ['check-manifest'],
         'test': ['coverage'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37-dj2,py38-dj2,py39-dj2,py37-dj3,py38-dj3,py39-dj3
+envlist = py37-dj3,py38-dj3,py39-dj3
 
 [testenv]
 deps =
@@ -14,7 +14,6 @@ deps =
     pyodbc~=4.0.21
     django-informixdb~=1.10.0
 
-    dj2: django~=2.2.0
     dj3: django~=3.2.0
 commands =
     pylint django_informixdb_vault


### PR DESCRIPTION
Django 2.2 has finished receiving any updates as at April, 2022

https://docs.djangoproject.com/en/4.0/releases/2.2/