### PR TITLE
Update for newer GitHub actions; also don't calculate the version twice

### DIFF
--- a/.github/workflows/test-build-release.yaml
+++ b/.github/workflows/test-build-release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run tests
         shell: bash
@@ -23,18 +23,20 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    outputs:
+      version: "${{ steps.version.outputs.version }}"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get next version
-        uses: reecetech/version-increment@2022.2.5
+        uses: reecetech/version-increment@2024.10.1
         id: version
         with:
           scheme: semver
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'  # Should match Pipfile / "python_version"
 
@@ -47,11 +49,12 @@ jobs:
           pip install "setuptools>=62.2.0"
           python3 setup.py sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
           retention-days: 3
+          include-hidden-files: true
 
   release:
     if: ${{ github.ref == 'refs/heads/master' }}
@@ -60,17 +63,8 @@ jobs:
       - build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Get next version
-        uses: reecetech/version-increment@2022.2.5
-        id: version
-        with:
-          scheme: semver
-
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist  # the name of the artefact from the `build` step
           path: dist/
@@ -81,7 +75,7 @@ jobs:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           draft: false
           prerelease: false
-          automatic_release_tag: "${{ steps.version.outputs.version }}"
+          automatic_release_tag: "${{ needs.build.outputs.version }}"
 
       - name: Release version on PyPi
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test-build-release.yaml
+++ b/.github/workflows/test-build-release.yaml
@@ -34,6 +34,7 @@ jobs:
         id: version
         with:
           scheme: semver
+          pep440: true
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test-build-release.yaml
+++ b/.github/workflows/test-build-release.yaml
@@ -57,7 +57,7 @@ jobs:
           include-hidden-files: true
 
   release:
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref_name == github.event.repository.default_branch }}
     needs:
       - test
       - build


### PR DESCRIPTION
Artifact API's have changed, and v3 is deprecated