### PR TITLE
Refresh credentials from Vault every hour or as specified in settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,14 +23,15 @@ Settings Required
 
 Do not provide `USER` and `PASSWORD`.  Instead provide these settings:
 
-============================  ===========  ===========
-Setting                       Required     Description
-============================  ===========  ===========
-`VAULT_ADDR`                  Yes          The HTTPS endpoint for Vault
-`VAULT_PATH`                  Yes          The path in Vault to the KV v2 secret storing the Informix credentials
-`VAULT_K8S_AUTH_MOUNT_POINT`  No           The Vault mount point to use for Kubernetes authentication, default value: ``kubernetes``
-`VAULT_K8S_JWT`               No           The path to the JWT in a K8s container, default vault: ``/var/run/secrets/kubernetes.io/serviceaccount/token``
-`VAULT_K8S_ROLE`              Conditional  Provide the K8s role *if* using K8s JWT authentication to Vault
-`VAULT_KVV2_MOUNT_POINT`      No           The Vault mount point to use for KVv2 secrets, default value: ``secret``
-`VAULT_TOKEN`                 Conditional  Provide the token *if* using basic token authentication to Vault
-============================  ===========  ===========
+=================================== ===========  ===========
+Setting                             Required     Description
+=================================== ===========  ===========
+`VAULT_ADDR`                        Yes          The HTTPS endpoint for Vault
+`VAULT_PATH`                        Yes          The path in Vault to the KV v2 secret storing the Informix credentials
+`VAULT_K8S_AUTH_MOUNT_POINT`        No           The Vault mount point to use for Kubernetes authentication, default value: ``kubernetes``
+`VAULT_K8S_JWT`                     No           The path to the JWT in a K8s container, default value: ``/var/run/secrets/kubernetes.io/serviceaccount/token``
+`VAULT_K8S_ROLE`                    Conditional  Provide the K8s role *if* using K8s JWT authentication to Vault
+`VAULT_KVV2_MOUNT_POINT`            No           The Vault mount point to use for KVv2 secrets, default value: ``secret``
+`VAULT_TOKEN`                       Conditional  Provide the token *if* using basic token authentication to Vault
+`VAULT_MAXIMUM_CREDENTIAL_LIFETIME` No           Time interval (seconds) to force retrieving credentials from Vault, default value: ``3600``
+=================================== ===========  ===========

--- a/django_informixdb_vault/base.py
+++ b/django_informixdb_vault/base.py
@@ -178,10 +178,14 @@ class DatabaseWrapper(base.DatabaseWrapper):
         if maximum_credential_lifetime and 'CREDENTIALS_START_TIME' in self.settings_dict:
             elapsed = datetime.now() - self.settings_dict['CREDENTIALS_START_TIME']
             credentials_need_refresh = elapsed.seconds >= maximum_credential_lifetime
-        else:
+        elif maximum_credential_lifetime:
+            # Settings configured for refreshes but we don't yet have a credential start time
             credentials_need_refresh = True
+        else:
+            # Don't refresh if VAULT_MAXIMUM_CREDENTIAL_LIFETIME is set to None
+            credentials_need_refresh = False
 
-        if (username and password and not credentials_need_refresh):
+        if username and password and not credentials_need_refresh:
             conn_params['USER'] = username
             conn_params['PASSWORD'] = password
 


### PR DESCRIPTION
Refresh credentials from Vault every hour by default, or using an interval configured by the VAULT_MAXIMUM_CREDENTIAL_LIFETIME setting.